### PR TITLE
Update: drag reorder, localStorage persistence, graph click-select, a…

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -16,6 +16,9 @@
       user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
     -->
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@800&display=swap" rel="stylesheet" />
     <!--
       Notice the use of %PUBLIC_URL% in the tags above.
       It will be replaced with the URL of the `public` folder during the build.

--- a/src/App.css
+++ b/src/App.css
@@ -10,51 +10,55 @@
   --bg-item:          #1f2937;
   --border:           #374151;
   --border-faint:     #1f2937;
-  --text:             #d1d5db;
-  --text-dim:         #6b7280;
-  --text-muted:       #4b5563;
+  --text:             #f8fafc;
+  --text-dim:         #e2e8f0;
+  --text-muted:       #cbd5e1;
   --accent:           #93c5fd;
   --btn-bg:           #1d4ed8;
   --btn-hover:        #2563eb;
   --remove-hover:     #ef4444;
   --selected-bg:      #1e3a5f;
   --selected-border:  #60a5fa;
-  --info-value:       #d1d5db;
-  --fit-color:        #6b7280;
+  --info-value:       #f8fafc;
+  --fit-color:        #cbd5e1;
   --fit-hover-border: #60a5fa;
   --fit-hover-color:  #93c5fd;
-  --empty-hint:       #4b5563;
+  --empty-hint:       #cbd5e1;
+  --divider-dot:      rgba(255, 255, 255, 0.25);
 
   padding: 20px 24px;
   font-family: 'Courier New', Consolas, monospace;
   background: var(--bg);
   min-height: 100vh;
+  display: flex;
+  flex-direction: column;
   color: var(--text);
   transition: background 0.2s, color 0.2s;
 }
 
 /* ── Light theme ──────────────────────────────── */
 .App.light {
-  --bg:               #bfdbfe;   /* saturated blue — white panels clearly pop */
+  --bg:               #eef3fe;
   --bg-panel:         #ffffff;
   --bg-input:         #ffffff;
   --bg-item:          #ffffff;
   --border:           #3b82f6;   /* strong visible blue */
-  --border-faint:     #93c5fd;
-  --text:             #0f172a;   /* near-black for max readability */
-  --text-dim:         #1d4ed8;
-  --text-muted:       #374151;
+  --border-faint:     #c2d3ef;   /* muted blue-grey — visible but soft against #eef3fe */
+  --text:             #000000;   /* pure black */
+  --text-dim:         #020617;   /* near-black — labels */
+  --text-muted:       #0f172a;   /* dark navy — placeholders, tagline */
   --accent:           #1d4ed8;
   --btn-bg:           #1d4ed8;
   --btn-hover:        #1e40af;
   --remove-hover:     #dc2626;
   --selected-bg:      #dbeafe;
   --selected-border:  #1d4ed8;
-  --info-value:       #0f172a;
-  --fit-color:        #374151;
+  --info-value:       #000000;
+  --fit-color:        #020617;
   --fit-hover-border: #1d4ed8;
   --fit-hover-color:  #1d4ed8;
-  --empty-hint:       #475569;
+  --empty-hint:       #0f172a;
+  --divider-dot:      rgba(30, 64, 175, 0.35);
 }
 
 /* ── Header ───────────────────────────────────── */
@@ -64,27 +68,42 @@
   align-items: center;
   justify-content: space-between;
   margin-bottom: 20px;
+  flex-shrink: 0;
 }
 
 .header-title {
   display: flex;
   align-items: baseline;
-  gap: 12px;
+  gap: 14px;
 }
 
 .header-tagline {
   font-size: 0.8rem;
   color: var(--text-muted);
   letter-spacing: 0.03em;
-  opacity: 0.75;
 }
 
 .App h1 {
   margin: 0;
-  font-size: 1.3rem;
+  font-family: 'Space Grotesk', sans-serif;
+  font-size: 2rem;
   letter-spacing: 0.06em;
   color: var(--accent);
-  font-weight: 600;
+  font-weight: 800;
+  text-transform: uppercase;
+}
+
+@keyframes titleCharIn {
+  0%   { opacity: 0; transform: translateY(10px) scaleY(0.8); }
+  60%  { opacity: 1; transform: translateY(-2px) scaleY(1.05); }
+  100% { opacity: 1; transform: translateY(0)   scaleY(1); }
+}
+
+.title-char {
+  display: inline-block;
+  opacity: 0;
+  animation: titleCharIn 0.35s cubic-bezier(0.22, 1, 0.36, 1) forwards;
+  animation-delay: calc(var(--i) * 55ms);
 }
 
 .theme-toggle {
@@ -111,7 +130,8 @@
   display: flex;
   gap: 5px;
   align-items: stretch;
-  min-height: calc(100vh - 80px);
+  flex: 1;
+  min-height: 0;
 }
 
 .sidebar {
@@ -128,11 +148,23 @@
   background: var(--border-faint);
   border-radius: 3px;
   transition: background 0.15s;
+  position: relative;
 }
 
 .divider:hover,
 .divider:active {
   background: var(--accent);
+}
+
+/* 3-dot grip indicator */
+.divider::after {
+  content: '';
+  position: absolute;
+  border-radius: 50%;
+  background: var(--divider-dot);
+  box-shadow: 0 0 0 var(--divider-dot); /* overridden per axis below */
+  pointer-events: none;
+  transition: background 0.15s, box-shadow 0.15s;
 }
 
 .divider-v {
@@ -142,11 +174,35 @@
   margin: 0 2px;
 }
 
+/* vertical divider: 3 dots stacked */
+.divider-v::after {
+  width: 3px;
+  height: 3px;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  box-shadow:
+    0 -7px 0 var(--divider-dot),
+    0  7px 0 var(--divider-dot);
+}
+
 .divider-h {
   width: 100%;
   height: 5px;
   cursor: row-resize;
   margin: 4px 0;
+}
+
+/* horizontal divider: 3 dots in a row */
+.divider-h::after {
+  width: 3px;
+  height: 3px;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  box-shadow:
+    -7px 0 0 var(--divider-dot),
+     7px 0 0 var(--divider-dot);
 }
 
 .chart-area {
@@ -232,9 +288,9 @@
 
 .empty-hint {
   color: var(--empty-hint);
+  font-family: 'Courier New', Consolas, monospace;
   font-size: 0.78rem;
   text-align: center;
-  padding: 10px 0;
   margin: 0;
 }
 
@@ -260,6 +316,25 @@
 .cidr-item.selected {
   border-color: var(--selected-border);
   background: var(--selected-bg);
+}
+
+.cidr-drag-handle {
+  cursor: grab;
+  color: var(--text-muted);
+  font-size: 1rem;
+  flex-shrink: 0;
+  opacity: 0.45;
+  line-height: 1;
+  user-select: none;
+}
+
+.cidr-drag-handle:active {
+  cursor: grabbing;
+}
+
+.cidr-item.dragging {
+  border-color: var(--selected-border);
+  cursor: grabbing;
 }
 
 .cidr-dot {
@@ -297,6 +372,7 @@
   border: 1px solid var(--border);
   border-radius: 4px;
   padding: 12px;
+  margin: 14px 0 0 0;
 }
 
 .cidr-info-title {

--- a/src/App.js
+++ b/src/App.js
@@ -13,22 +13,47 @@ const validateCidr = (cidr) => {
   return true;
 };
 
+// Safe localStorage helpers
+const ls = {
+  get: (key, fallback) => {
+    try {
+      const v = localStorage.getItem(key);
+      return v !== null ? JSON.parse(v) : fallback;
+    } catch { return fallback; }
+  },
+  set: (key, value) => {
+    try { localStorage.setItem(key, JSON.stringify(value)); } catch {}
+  },
+};
+
 function App() {
-  const [cidrList, setCidrList] = useState([]);
+  const [cidrList, setCidrList] = useState(() => ls.get('cidr-lens:cidrList', []));
   const [cidrInput, setCidrInput] = useState('');
   const [selectedCidr, setSelectedCidr] = useState(null);
   const [fitTrigger, setFitTrigger] = useState(0);
-  const [theme, setTheme] = useState('dark');
+  const [theme, setTheme] = useState(() => ls.get('cidr-lens:theme', 'dark'));
+  const [dragState, setDragState] = useState(null);
+  // dragState: { idx, dy, insertIdx, itemHeight } | null
+  const itemRefs = useRef([]);
 
-  // Pane sizes — initialised from viewport so proportions hold at any resolution
+  // Pane sizes — restored from localStorage, falling back to viewport-relative defaults
   const usableH = () => window.innerHeight - LAYOUT.HEADER_HEIGHT_PX;
-  const [sidebarWidth, setSidebarWidth] = useState(() => Math.round(window.innerWidth * LAYOUT.SIDEBAR_INIT_VW));
-  const [ganttHeight,  setGanttHeight]  = useState(() => Math.round(usableH() * LAYOUT.GANTT_INIT_VH));
-  const [listHeight,   setListHeight]   = useState(() => Math.round(usableH() * LAYOUT.LIST_INIT_VH));
-  const [chartAreaWidth, setChartAreaWidth] = useState(
-    () => Math.round(window.innerWidth * (1 - LAYOUT.SIDEBAR_INIT_VW) - 60)
-  );
+  const [sidebarWidth, setSidebarWidth] = useState(() =>
+    ls.get('cidr-lens:sidebarWidth', Math.round(window.innerWidth * LAYOUT.SIDEBAR_INIT_VW)));
+  const [ganttHeight,  setGanttHeight]  = useState(() =>
+    ls.get('cidr-lens:ganttHeight',  Math.round(usableH() * LAYOUT.GANTT_INIT_VH)));
+  const [listHeight,   setListHeight]   = useState(() =>
+    ls.get('cidr-lens:listHeight',   Math.round(usableH() * LAYOUT.LIST_INIT_VH)));
+  const [chartAreaWidth, setChartAreaWidth] = useState(null);
   const chartAreaRef = useRef(null);
+
+  useEffect(() => {
+    ls.set('cidr-lens:cidrList',    cidrList);
+    ls.set('cidr-lens:theme',       theme);
+    ls.set('cidr-lens:sidebarWidth', sidebarWidth);
+    ls.set('cidr-lens:ganttHeight',  ganttHeight);
+    ls.set('cidr-lens:listHeight',   listHeight);
+  }, [cidrList, theme, sidebarWidth, ganttHeight, listHeight]);
 
   useEffect(() => {
     if (!chartAreaRef.current) return;
@@ -83,6 +108,73 @@ function App() {
     setCidrInput('');
   };
 
+  const handleDragHandleMouseDown = (e, index) => {
+    e.preventDefault();
+    e.stopPropagation();
+
+    const rects = itemRefs.current.map(el => el ? el.getBoundingClientRect() : null);
+    const itemHeight = rects[index]?.height || 34;
+    const startY = e.clientY;
+    let currentInsertIdx = index;
+
+    const computeInsertIdx = (clientY) => {
+      const dy = clientY - startY;
+      const draggedCenter = rects[index].top + itemHeight / 2 + dy;
+      let insert = index;
+      for (let i = 0; i < rects.length; i++) {
+        if (i === index || !rects[i]) continue;
+        const center = rects[i].top + rects[i].height / 2;
+        if (i < index && draggedCenter < center) insert = Math.min(insert, i);
+        else if (i > index && draggedCenter > center) insert = i;
+      }
+      return insert;
+    };
+
+    setDragState({ idx: index, dy: 0, insertIdx: index, itemHeight });
+
+    const onMouseMove = (ev) => {
+      const dy = ev.clientY - startY;
+      currentInsertIdx = computeInsertIdx(ev.clientY);
+      setDragState({ idx: index, dy, insertIdx: currentInsertIdx, itemHeight });
+    };
+
+    const onMouseUp = () => {
+      document.removeEventListener('mousemove', onMouseMove);
+      document.removeEventListener('mouseup', onMouseUp);
+      if (index !== currentInsertIdx) {
+        setCidrList(list => {
+          const newList = [...list];
+          const [moved] = newList.splice(index, 1);
+          newList.splice(currentInsertIdx, 0, moved);
+          return newList;
+        });
+      }
+      setDragState(null);
+    };
+
+    document.addEventListener('mousemove', onMouseMove);
+    document.addEventListener('mouseup', onMouseUp);
+  };
+
+  const getItemStyle = (index) => {
+    if (!dragState) return {};
+    const { idx, dy, insertIdx, itemHeight } = dragState;
+    const gap = itemHeight + 4; // 4px = margin-bottom
+    if (index === idx) {
+      return {
+        transform: `translateY(${dy}px)`,
+        zIndex: 100,
+        opacity: 0.85,
+        transition: 'none',
+        boxShadow: '0 6px 20px rgba(0,0,0,0.22)',
+      };
+    }
+    let shift = 0;
+    if (idx < insertIdx && index > idx && index <= insertIdx) shift = -gap;
+    else if (idx > insertIdx && index < idx && index >= insertIdx) shift = gap;
+    return { transform: `translateY(${shift}px)`, transition: 'transform 0.15s ease' };
+  };
+
   const handleRemoveCidr = (cidr) => {
     setCidrList(cidrList.filter(c => c.cidr !== cidr));
     if (selectedCidr === cidr) setSelectedCidr(null);
@@ -100,7 +192,13 @@ function App() {
 
       <div className="header">
         <div className="header-title">
-          <h1>CIDR Lens</h1>
+          <h1>
+            {'CIDR Lens'.split('').map((char, i) => (
+              <span key={i} className="title-char" style={{ '--i': i }}>
+                {char === ' ' ? '\u00A0' : char}
+              </span>
+            ))}
+          </h1>
           <span className="header-tagline">IPv4 CIDR Calculator &amp; Visualizer</span>
         </div>
         <button
@@ -132,15 +230,25 @@ function App() {
             </button>
           )}
 
-          <div className="cidr-list" style={{ height: listHeight, overflowY: 'auto' }}>
+          <div
+            className="cidr-list"
+            style={{ height: listHeight, overflowY: dragState ? 'visible' : 'auto' }}
+          >
             {cidrList.length === 0
               ? <p className="empty-hint">No CIDRs added yet.</p>
-              : cidrList.map(({ cidr, color }) => (
+              : cidrList.map(({ cidr, color }, index) => (
                 <div
                   key={cidr}
-                  className={`cidr-item${selectedCidr === cidr ? ' selected' : ''}`}
-                  onClick={() => setSelectedCidr(selectedCidr === cidr ? null : cidr)}
+                  ref={el => { itemRefs.current[index] = el; }}
+                  className={`cidr-item${selectedCidr === cidr ? ' selected' : ''}${dragState?.idx === index ? ' dragging' : ''}`}
+                  style={{ position: 'relative', ...getItemStyle(index) }}
+                  onClick={() => !dragState && setSelectedCidr(selectedCidr === cidr ? null : cidr)}
                 >
+                  <span
+                    className="cidr-drag-handle"
+                    onMouseDown={(e) => handleDragHandleMouseDown(e, index)}
+                    onClick={(e) => e.stopPropagation()}
+                  >⠿</span>
                   <span className="cidr-dot" style={{ background: color }} />
                   <span className="cidr-label">{cidr}</span>
                   <button
@@ -181,13 +289,17 @@ function App() {
         <div className="divider divider-v" onMouseDown={startVerticalDrag} />
 
         <div className="chart-area" ref={chartAreaRef}>
+          {chartAreaWidth !== null && (
           <Gantt
             w={chartAreaWidth}
             h={ganttHeight}
             tasks={tasks}
             fitTrigger={fitTrigger}
             theme={theme}
+            selectedCidr={selectedCidr}
+            onSelectCidr={(cidr) => setSelectedCidr(prev => prev === cidr ? null : cidr)}
           />
+          )}
           <div className="divider divider-h" onMouseDown={startHorizontalDrag} />
           <BinaryView
             cidrList={cidrList}

--- a/src/BinaryView.css
+++ b/src/BinaryView.css
@@ -22,7 +22,7 @@
 .binary-view--dark .octet-dot         { color: #6b7280; }
 .binary-view--dark .bit-cell--host    { background: #111827; border-color: #374151; color: #4b5563; }
 .binary-view--dark .span-host         { background: #111827; border: 1px solid #374151; color: #4b5563; }
-.binary-view--dark .binary-empty      { color: #4b5563; }
+.binary-view--dark .binary-empty      { color: var(--empty-hint); }
 .binary-view--dark .binary-label      { color: #6b7280; }
 
 /* ── Light ────────────────────────────────────── */
@@ -30,16 +30,16 @@
 .binary-view--light {
   background: #ffffff;
   border: 1px solid #3b82f6;
-  color: #0f172a;
+  color: #000000;
 }
 
-.binary-view--light .binary-row-label  { color: #1e293b; font-weight: 600; }
-.binary-view--light .octet-value       { color: #1e293b; font-weight: 700; }
+.binary-view--light .binary-row-label  { color: #020617; font-weight: 600; }
+.binary-view--light .octet-value       { color: #020617; font-weight: 700; }
 .binary-view--light .octet-dot         { color: #1d4ed8; }
-.binary-view--light .bit-cell--host    { background: #e2e8f0; border-color: #64748b; color: #374151; }
-.binary-view--light .span-host         { background: #e2e8f0; border: 1px solid #64748b; color: #374151; }
-.binary-view--light .binary-empty      { color: #475569; }
-.binary-view--light .binary-label      { color: #1e293b; font-weight: 600; }
+.binary-view--light .bit-cell--host    { background: #e2e8f0; border-color: #64748b; color: #1e293b; }
+.binary-view--light .span-host         { background: #e2e8f0; border: 1px solid #64748b; color: #1e293b; }
+.binary-view--light .binary-empty      { color: var(--empty-hint); }
+.binary-view--light .binary-label      { color: #020617; font-weight: 600; }
 
 /* ── Header ───────────────────────────────────── */
 
@@ -193,6 +193,7 @@
 }
 
 .binary-empty {
+  font-family: 'Courier New', Consolas, monospace;
   font-size: 0.78rem;
   text-align: center;
   padding: 8px 0;

--- a/src/Gantt.js
+++ b/src/Gantt.js
@@ -4,11 +4,16 @@ import { numberToIpv4 } from './helpers.js';
 import { IPV4_MAX, MIN_BAR_PX, SVG_OVERFLOW_PAD, GANTT_THEME } from './constants.js';
 import './Gantt.css';
 
-const GanttChart = ({ w = 800, h = 400, tasks = [], fitTrigger = 0, theme = 'dark' }) => {
+const GanttChart = ({ w = 800, h = 400, tasks = [], fitTrigger = 0, theme = 'dark', selectedCidr = null, onSelectCidr }) => {
   const svgRef = useRef();
   const transformRef = useRef(null);
   const prevTaskKeysRef = useRef('');
   const prevFitTriggerRef = useRef(0);
+  // Stable refs so click handlers never capture stale closure values
+  const selectedCidrRef = useRef(selectedCidr);
+  const onSelectCidrRef = useRef(onSelectCidr);
+  useEffect(() => { selectedCidrRef.current = selectedCidr; }, [selectedCidr]);
+  useEffect(() => { onSelectCidrRef.current = onSelectCidr; }, [onSelectCidr]);
 
   useEffect(() => {
     const svg = d3.select(svgRef.current);
@@ -57,8 +62,15 @@ const GanttChart = ({ w = 800, h = 400, tasks = [], fitTrigger = 0, theme = 'dar
         .attr('width', d => xScale(d.end) - xScale(d.start))
         .attr('height', yScale.bandwidth())
         .attr('fill', d => d.color || 'steelblue')
-        .attr('opacity', 0.85)
-        .attr('rx', 2);
+        .attr('opacity', d => selectedCidrRef.current === null ? 0.85 : d.task === selectedCidrRef.current ? 1.0 : 0.35)
+        .attr('stroke', d => d.task === selectedCidrRef.current ? colors.selectedStroke : 'none')
+        .attr('stroke-width', d => d.task === selectedCidrRef.current ? 1.5 : 0)
+        .attr('rx', 2)
+        .style('cursor', 'pointer')
+        .on('click', (event, d) => {
+          event.stopPropagation();
+          onSelectCidrRef.current?.(d.task);
+        });
     }
 
     const xAxis = d3.axisBottom(xScale).ticks(8).tickFormat(numberToIpv4);
@@ -167,9 +179,19 @@ const GanttChart = ({ w = 800, h = 400, tasks = [], fitTrigger = 0, theme = 'dar
 
   }, [tasks, w, h, fitTrigger, theme]);
 
+  // Update bar highlight whenever selection or theme changes — no full redraw needed
+  useEffect(() => {
+    const colors = GANTT_THEME[theme] || GANTT_THEME.dark;
+    const svg = d3.select(svgRef.current);
+    svg.selectAll('.bars')
+      .attr('opacity', d => selectedCidr === null ? 0.85 : d.task === selectedCidr ? 1.0 : 0.35)
+      .attr('stroke', d => d.task === selectedCidr ? colors.selectedStroke : 'none')
+      .attr('stroke-width', d => d.task === selectedCidr ? 1.5 : 0);
+  }, [selectedCidr, theme]);
+
   return (
       <div style={{ width: w + SVG_OVERFLOW_PAD, height: h + SVG_OVERFLOW_PAD, overflow: 'hidden' }}>
-        <svg ref={svgRef} width={w} height={h} style={{ overflow: 'visible' }}></svg>
+        <svg ref={svgRef} width={w} height={h} style={{ overflow: 'visible', fontFamily: "'Courier New', Consolas, monospace" }}></svg>
       </div>
   );
 };

--- a/src/constants.js
+++ b/src/constants.js
@@ -25,22 +25,24 @@ export const LAYOUT = {
   GANTT_MIN_VH:       0.15,
   GANTT_MAX_VH:       0.85,
 
-  LIST_INIT_VH:       0.54,  // CIDR list starting height inside sidebar
+  LIST_INIT_VH:       0.50,  // CIDR list starting height inside sidebar
   LIST_MIN_VH:        0.05,
 };
 
 // ── Theme colours (consumed by the D3 Gantt chart) ────────────────────────
 export const GANTT_THEME = {
   dark: {
-    chartBg:   '#0a1628',
-    axisText:  '#6b7280',
-    axisLine:  '#374151',
-    emptyHint: '#445566',
+    chartBg:        '#0a1628',
+    axisText:       '#cbd5e1',
+    axisLine:       '#374151',
+    emptyHint:      '#cbd5e1',
+    selectedStroke: '#ffffff',
   },
   light: {
-    chartBg:   '#f0f9ff',
-    axisText:  '#1e293b',
-    axisLine:  '#60a5fa',
-    emptyHint: '#64748b',
+    chartBg:        '#f0f9ff',
+    axisText:       '#0f172a',
+    axisLine:       '#60a5fa',
+    emptyHint:      '#0f172a',
+    selectedStroke: '#0f172a',
   },
 };

--- a/src/index.css
+++ b/src/index.css
@@ -11,4 +11,4 @@ body {
 
 /* body background tracks whichever theme .App is using */
 .App      { background: #111827; }
-.App.light { background: #bfdbfe; }
+.App.light { background: #eef3fe; }


### PR DESCRIPTION
…nd polish

  CIDR list drag reordering
  - Replaced HTML5 drag-and-drop with mouse-based drag for live animation
  - Dragged item follows cursor with lift shadow; surrounding items slide smoothly out of the way using CSS transform transitions
  - Selection state preserved correctly when list is reordered

  localStorage persistence
  - Persists cidrList, theme, sidebarWidth, ganttHeight, listHeight across reloads
  - Safe ls helper with try/catch for private browsing / storage quota
  - Pane sizes restored from saved values with viewport-relative fallbacks

  Graph click-to-select
  - Clicking a Gantt bar selects the corresponding CIDR (toggle, same as sidebar)
  - Selected bar highlights at full opacity with themed stroke border; unselected bars dim to 0.35 opacity
  - Stable refs prevent stale closure issues in D3 click handlers
  - Sidebar and graph selection stay in sync via shared selectedCidr state

  Bug fixes
  - Fixed default vertical scrollbar: App is now a flex column (min-height: 100vh) with layout using flex: 1 so no magic calc() needed
  - Fixed Gantt bars disappearing on reload: chartAreaWidth starts null and only renders Gantt once ResizeObserver provides the real DOM width, eliminating stale fit-transform applied to a mismatched xScale
  - Fixed selected bar stroke invisible in light mode: added selectedStroke to GANTT_THEME (white for dark, #0f172a for light)
  - Fixed selection highlight not reapplied after list reorder: bars now initialised with correct opacity/stroke from selectedCidrRef on every redraw

  Light mode text contrast
  - Pushed all light mode text toward pure black: --text #000, --text-dim #020617, --text-muted / --empty-hint #0f172a
  - GANTT_THEME light axisText and emptyHint updated to match
  - BinaryView light mode text darkened to match